### PR TITLE
Don't set fold* if foldMethodVersion < 1

### DIFF
--- a/ftplugin/viki.vim
+++ b/ftplugin/viki.vim
@@ -43,9 +43,11 @@ exec "setlocal commentstring=". substitute(b:vikiCommentStart, "%", "%%", "g")
             \ ."%s". substitute(b:vikiCommentEnd, "%", "%%", "g")
 exec "setlocal comments=fb:-,fb:+,fb:*,fb:#,fb:?,fb:@,:". b:vikiCommentStart
 
-setlocal foldmethod=expr
-setlocal foldexpr=VikiFoldLevel(v:lnum)
-setlocal foldtext=VikiFoldText()
+if g:vikiFoldMethodVersion > 0
+  setlocal foldmethod=expr
+  setlocal foldexpr=VikiFoldLevel(v:lnum)
+  setlocal foldtext=VikiFoldText()
+endif
 setlocal expandtab
 " setlocal iskeyword+=#,{
 setlocal iskeyword+={


### PR DESCRIPTION
Hi,

I want to use a different fold method (vxfold) in my Viki files and I want to
set it on au FileType. Unfortunately the foldmethod is unconditionally set in
ftplugin/viki.vim. With this patch the foldmethod is set only when
vikiVoldMethodVersion is more than 0. Now this will work form .vimrc:

```
  let g:vikiFoldMethodVersion = 0
  au FileType viki VxFoldViki
```
